### PR TITLE
add 新增 媒体文件扫描API

### DIFF
--- a/core/src/main/java/net/codeocean/cheese/backend/impl/FilesImpl.kt
+++ b/core/src/main/java/net/codeocean/cheese/backend/impl/FilesImpl.kt
@@ -51,4 +51,8 @@ object FilesImpl : Files {
     override fun save(obj: Any, filePath: String): Boolean {
         return FilesUtils.save(obj, filePath)
     }
+
+    override fun scanFile(path: String) {
+        return FilesUtils.scanFile(path)
+    }
 }

--- a/core/src/main/java/net/codeocean/cheese/core/api/Files.kt
+++ b/core/src/main/java/net/codeocean/cheese/core/api/Files.kt
@@ -11,4 +11,5 @@ interface Files {
     fun append(filePath: String, content: String): Boolean
     fun write(filePath: String, content: String): Boolean
     fun save(obj: Any, filePath: String): Boolean
+    fun scanFile(path: String)
 }

--- a/core/src/main/java/net/codeocean/cheese/core/utils/FilesUtils.kt
+++ b/core/src/main/java/net/codeocean/cheese/core/utils/FilesUtils.kt
@@ -14,6 +14,8 @@ import java.io.FileWriter
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
+import android.media.MediaScannerConnection
+import net.codeocean.cheese.core.CoreEnv
 
 object FilesUtils {
 
@@ -387,6 +389,17 @@ object FilesUtils {
             }
         }
         return result
+    }
+
+    fun scanFile(path: String) {
+        synchronized(this) {
+            MediaScannerConnection.scanFile(
+                CoreEnv.envContext.context,
+                arrayOf(path),
+                null,
+                null
+            )
+        }
     }
 
 }


### PR DESCRIPTION
使用copy复制图片文件时，图片无法更新到相册里面，需要使用媒体文件扫描API进行更新，才会出现相册里